### PR TITLE
feat: optimize get_all_pies_with_holdings performance and make timeout configurable

### DIFF
--- a/trading212-mcp-server/tests/mcp_protocol_tests.rs
+++ b/trading212-mcp-server/tests/mcp_protocol_tests.rs
@@ -362,6 +362,7 @@ async fn test_real_mcp_error_handling() {
 
 /// Real integration test: Call get_all_pies_with_holdings tool via MCP protocol
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn test_real_mcp_call_get_pies() {
     let mock_server = MockServer::start().await;
 
@@ -398,16 +399,33 @@ async fn test_real_mcp_call_get_pies() {
                 "ticker": "AAPL_US_EQ",
                 "expectedShare": 1.0,
                 "currentShare": 1.0,
-                "ownedQuantity": 10.0
+                "ownedQuantity": 10.0,
+                "result": {
+                    "priceAvgInvestedValue": 100.0,
+                    "priceAvgValue": 110.0,
+                    "priceAvgResult": 10.0,
+                    "priceAvgResultCoef": 0.1
+                },
+                "issues": []
             }],
             "settings": {
                 "id": 12345,
                 "name": "Test Pie",
                 "icon": null,
                 "goal": null,
-                "dividendCashAction": "REINVEST"
+                "dividendCashAction": "REINVEST",
+                "creationDate": 1_704_067_200.0
             }
         })))
+        .mount(&mock_server)
+        .await;
+
+    // Mock instruments metadata endpoint for enriching instrument names
+    Mock::given(method("GET"))
+        .and(path("/equity/metadata/instruments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            {"ticker": "AAPL_US_EQ", "name": "Apple Inc", "shortName": "AAPL", "type": "STOCK"}
+        ])))
         .mount(&mock_server)
         .await;
 


### PR DESCRIPTION
## Summary

This PR introduces two key improvements to the Trading212 MCP server:

- **Performance optimization**: Refactored `get_all_pies_with_holdings` to fetch all instrument metadata in a single batched request instead of making individual requests per pie, significantly reducing API calls and improving response time
- **Configurable request timeout**: Added `MCP_REQUEST_TIMEOUT_SECS` environment variable to allow users to customize the HTTP request timeout (default increased from 60s to 120s to accommodate the Trading212 API's response times)

### Key Changes

**Performance improvements** (`src/tools.rs`):
- Changed from sequential per-pie instrument lookups to a single bulk fetch of all instruments
- Collect all unique tickers across pies, fetch instrument metadata once, then enrich all pies
- Leverages the 60s instrument cache to avoid redundant API calls
- Removed partial failure handling for individual pies (now only returns successfully fetched pies)

**Configurable timeout** (`src/bin/remote-server.rs`):
- Added `MCP_REQUEST_TIMEOUT_SECS` environment variable support
- Increased default timeout from 60s to 120s
- Added info-level logging for configured timeout value

**Test updates**:
- Updated tests to mock the new bulk instruments endpoint
- Adjusted test expectations to reflect new behavior (only successful pies returned)

## Test plan

- [x] Unit tests pass for updated `get_all_pies_with_holdings` logic
- [x] Integration tests pass with new instrument enrichment flow
- [x] Manual testing with actual Trading212 API to verify performance improvement
- [x] Verified timeout configuration works with different values
- [x] All existing tests pass